### PR TITLE
Adjust heading-size to avoid spill in mobile-view

### DIFF
--- a/docs/_includes/about.html
+++ b/docs/_includes/about.html
@@ -26,15 +26,15 @@
           </p>
           <div class="codewrapper">
             <pre><code>
-            message PerformanceTestResult {
-              message Latency {
-                double min = 1;
-                double average = 2;
-                double p50 = 3;
-                double p90 = 4;
-                double p99 = 5;
-                double max = 6;
-              } ...</code></pre>
+message PerformanceTestResult {
+    message Latency {
+        double min = 1;
+        double average = 2;
+        double p50 = 3;
+        double p90 = 4;
+        double p99 = 5;
+        double max = 6;
+    } ...</code></pre>
             <p class="code-caption"> Snippet of the Service Mesh Performance describing how to capture statistical analysis. </p>
           </div>
           <div class="videowrapper"><br /><br />

--- a/docs/_includes/about.html
+++ b/docs/_includes/about.html
@@ -25,8 +25,7 @@
             The following snippet provides a further insight into the fact that the specification defines a common collection of statistical analysis to be calculated for every performance test:
           </p>
           <div class="codewrapper">
-            <pre><code>
-message PerformanceTestResult {
+            <pre><code>message PerformanceTestResult {
     message Latency {
         double min = 1;
         double average = 2;

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -57,6 +57,17 @@ a {
   }
 }
 
+@media(min-width:480px){
+    .page-section {
+      h1.section-heading {
+        font-size: 1.5em;
+      }
+      h2.section-heading {
+        font-size: 1.5em;
+    }
+  }
+}
+
 // Highlight color customization
 ::-moz-selection {
   background: $primary;

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -72,8 +72,10 @@ a {
       margin-right: 0;
     }
   }
-  iframe {
-    height: auto;
+  .about {
+    iframe {
+      height: auto;
+    }
   }
 }
 

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -58,14 +58,14 @@ a {
 }
 
 @media(max-width:480px){
-    .page-section {
-      padding-left: 1em;
-      padding-right: 1em;
-      h1.section-heading {
-        font-size: 1.5em;
-      }
-      h2.section-heading {
-        font-size: 1.5em;
+  .page-section {
+    padding-left: 1em;
+    padding-right: 1em;
+    h1.section-heading {
+      font-size: 1.5em;
+    }
+    h2.section-heading {
+      font-size: 1.5em;
     }
   }
 }

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -59,8 +59,8 @@ a {
 
 @media(max-width:480px){
     .page-section {
-      padding-left: 1rem;
-      padding-right: 1rem;
+      padding-left: 1em;
+      padding-right: 1em;
       h1.section-heading {
         font-size: 1.5em;
       }

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -57,7 +57,7 @@ a {
   }
 }
 
-@media(min-width:480px){
+@media(max-width:480px){
     .page-section {
       h1.section-heading {
         font-size: 1.5em;

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -59,6 +59,8 @@ a {
 
 @media(max-width:480px){
     .page-section {
+      padding-left: 1rem;
+      padding-right: 1rem;
       h1.section-heading {
         font-size: 1.5em;
       }

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -67,6 +67,13 @@ a {
     h2.section-heading {
       font-size: 1.5em;
     }
+    div.about-body {
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+  iframe {
+    height: auto;
   }
 }
 

--- a/docs/_sass/base/_page.scss
+++ b/docs/_sass/base/_page.scss
@@ -50,6 +50,18 @@ a {
     text-transform: none;
     @include serif-font;
   }
+
+  //For Specificity
+  .codewrapper{
+    pre {
+      code {
+        padding-top: 2em;
+        padding-bottom: 2em;
+        padding-left: 6em;
+        padding-right: 0;
+      }
+    }
+  }
 }
 @media(min-width:768px) {
   section {
@@ -70,6 +82,13 @@ a {
     div.about-body {
       margin-left: 0;
       margin-right: 0;
+    }
+    .codewrapper{
+      pre {
+        code {
+          padding-left: .7em;
+        }
+      }
     }
   }
   .about {


### PR DESCRIPTION
Signed-off-by: Jubayer Abdullah Joy <jubayerjoy98@gmail.com>

**Description**
The site tends to spill towards the right in mobile-view.
This issue was caused because the headings took more space then mobile-width.

Adjusted the heading `font-size` to fit the mobile-screen and avoid spilling.

This PR fixes #120 

**Notes for Reviewers**
Open up [smp-spec.io](https://smp-spec.io/) on your phone or in web devkit to see the error.
Open the [Netlify preview](https://deploy-preview-139--smp-spec.netlify.app) in your phone or web devkit to see the fixed version.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
